### PR TITLE
Change default file log level to INFO and add --debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ loups video.mp4 --no-log
 
 # Save results to file without progress display
 loups video.mp4 -q -o chapters.txt --no-log
+
+# Enable debug-level logging for troubleshooting
+loups video.mp4 --debug
 ```
 
 ## CLI Options
@@ -38,20 +41,22 @@ loups video.mp4 -q -o chapters.txt --no-log
 **Options:**
 - `-t, --template PATH`: Path to custom template image (defaults to bundled `template_solid.png`)
 - `-l, --log PATH`: Path to log file (default: `loups.log` in current directory)
-  - Automatically rotates at 5MB
+  - Automatically rotates at 10MB
   - Keeps 3 backup files
   - **Mutually exclusive with `--no-log`**
 - `--no-log`: Disable log file creation entirely
   - **Mutually exclusive with `--log`**
 - `-o, --output PATH`: Save results to file in YouTube chapter format
 - `-q, --quiet`: Suppress stdout progress display (errors still go to stderr)
+- `-d, --debug`: Enable DEBUG level logging to file (default is INFO)
 
 ## Important Notes
 
 **Logging Options:**
-- By default, logs are written to `loups.log` in the current directory
+- By default, logs are written to `loups.log` in the current directory at INFO level
 - Use `--log PATH` to specify a custom log file location
 - Use `--no-log` to disable logging completely
+- Use `--debug` to enable DEBUG level logging for detailed troubleshooting (default is INFO)
 - ⚠️ **You cannot use both `--log` and `--no-log` together** - they are mutually exclusive
 
 ## Features
@@ -59,6 +64,7 @@ loups video.mp4 -q -o chapters.txt --no-log
 - **Animated Progress Display**: Real-time scanning progress with softball animation 🥎
 - **Batter Detection**: Automatically finds and timestamps each batter appearance
 - **YouTube Chapter Format**: Outputs results ready for YouTube video chapters
-- **Log Rotation**: Automatic log rotation (5MB max, keeps 3 backups)
+- **Log Rotation**: Automatic log rotation (10MB max, keeps 3 backups)
+- **Flexible Logging**: INFO level by default, DEBUG level available with `--debug` flag
 - **Bundled Template**: Includes default template for Lights Out HB scoreboard
 - **Custom Templates**: Support for custom scoreboard templates

--- a/loups/cli.py
+++ b/loups/cli.py
@@ -42,7 +42,9 @@ def get_default_template() -> Path:
         )
 
 
-def setup_logging(log_path: Optional[Path] = None, quiet: bool = False) -> None:
+def setup_logging(
+    log_path: Optional[Path] = None, quiet: bool = False, debug: bool = False
+) -> None:
     """Set up logging with rotation."""
     # Configure root logger
     root_logger = logging.getLogger()
@@ -52,10 +54,11 @@ def setup_logging(log_path: Optional[Path] = None, quiet: bool = False) -> None:
     if log_path is not None:
         file_handler = RotatingFileHandler(
             log_path,
-            maxBytes=5 * 1024 * 1024,  # 5MB
+            maxBytes=10 * 1024 * 1024,  # 10MB
             backupCount=3,
         )
-        file_handler.setLevel(logging.DEBUG)
+        # Set file log level based on debug flag
+        file_handler.setLevel(logging.DEBUG if debug else logging.INFO)
         file_formatter = logging.Formatter(
             "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
         )
@@ -156,6 +159,12 @@ def main(
         "-q",
         help="Suppress stdout output (errors still go to stderr)",
     ),
+    debug: bool = typer.Option(  # noqa: B008
+        False,
+        "--debug",
+        "-d",
+        help="Enable DEBUG level logging to file (default is INFO)",
+    ),
 ) -> None:
     """Scan a Lights Out HB fastpitch game video and extract batter timestamps."""
     # Validate mutually exclusive options
@@ -175,7 +184,7 @@ def main(
         log_path = Path("./loups.log")
 
     # Set up logging
-    setup_logging(log_path, quiet)
+    setup_logging(log_path, quiet, debug)
 
     # Get template path
     if template is None:

--- a/loups/loups.py
+++ b/loups/loups.py
@@ -8,6 +8,7 @@ Game information currently extracted:
 """
 
 import logging
+import re
 from datetime import timedelta
 from typing import NamedTuple
 
@@ -269,13 +270,63 @@ class Loups:
         # Extract text
         ocr = Loups.reader.readtext(image_to_scan)
         logger.debug(f"{ocr=}")
-        text = [text for location, text, score in ocr if score > threshold]
 
-        # Ensure player number is after name
-        text = sorted(text, key=lambda item: "#" in item)
-        logger.debug(f"{text=}")
+        # Filter by confidence threshold
+        filtered_ocr = [
+            (location, text, score)
+            for location, text, score in ocr
+            if score > threshold
+        ]
 
-        return " ".join(text)
+        # Sort by x-coordinate (left-to-right) using the leftmost point
+        # OCR location can be:
+        # - [[top-left], [top-right], [bottom-right], [bottom-left]]
+        #   (list of points)
+        # - (x1, y1, x2, y2) (tuple of coordinates)
+        # For left-to-right reading, sort by x-coordinate of leftmost point
+        def get_leftmost_x(item):
+            location = item[0]
+            # Check if it's a list of points or a flat tuple
+            if isinstance(location[0], (list, tuple)) and len(location[0]) >= 2:
+                # List of points: [[x1, y1], [x2, y2], ...]
+                return min(point[0] for point in location)
+            else:
+                # Flat tuple: (x1, y1, x2, y2)
+                # x-coordinates are at even indices
+                return min(location[i] for i in range(0, len(location), 2))
+
+        sorted_ocr = sorted(filtered_ocr, key=get_leftmost_x)
+
+        # Extract just the text strings after sorting
+        text = [text for location, text, score in sorted_ocr]
+
+        # Extract jersey numbers and name parts from all elements
+        jersey_pattern = r"#\d+"
+
+        # Collect all jersey numbers from all text elements
+        # (now in left-to-right order)
+        all_jerseys = [
+            jersey for item in text for jersey in re.findall(jersey_pattern, item)
+        ]
+
+        # Collect all non-jersey text parts
+        # (remove jerseys, normalize spaces, preserve left-to-right order)
+        all_name_parts = [
+            re.sub(r"\s+", " ", re.sub(jersey_pattern, "", item).strip())
+            for item in text
+        ]
+
+        # Filter out empty strings
+        all_name_parts = [part for part in all_name_parts if part]
+
+        # Combine: name parts first (in left-to-right order), then jersey numbers
+        result = " ".join(all_name_parts + all_jerseys)
+        logger.debug(
+            f"text={text}, all_name_parts={all_name_parts}, "
+            f"all_jerseys={all_jerseys}, result={result}"
+        )
+
+        return result
 
     # def preprocess_frame(self):
     # self.logger.debug(f"{frame.shape[:2]=}")
@@ -331,7 +382,7 @@ class Loups:
                     new_batter=new_batter,
                     batter_name=new_batter_name,
                 )
-                logger.debug(f"{frame_batter_info=}")
+                logger.info(f"{frame_batter_info=}")
                 frames.append(frame_batter_info)
 
                 # Call callback if a new batter was found


### PR DESCRIPTION
The file logger now defaults to INFO level instead of DEBUG to reduce log verbosity. Users can enable DEBUG level logging with the new --debug/-d CLI flag when troubleshooting. Also increased log rotation size from 5MB to 10MB.

fixes #13