### PR TITLE
Enable pre-release package installation in TestPyPI workflow

### DIFF
--- a/.github/workflows/publish-to-testpypi.yaml
+++ b/.github/workflows/publish-to-testpypi.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install from TestPyPI
         run: |
-          pip install --index-url https://test.pypi.org/simple/ \
+          pip install --pre --index-url https://test.pypi.org/simple/ \
                       --extra-index-url https://pypi.org/simple/ \
                       loups
         shell: bash


### PR DESCRIPTION
## Summary
  - Add `--pre` flag to TestPyPI installation command to enable pre-release package installation

  ## Changes
  This PR updates the TestPyPI publishing workflow to properly install pre-release versions of the package during validation.

  **Modified**: `.github/workflows/publish-to-testpypi.yaml:96`
  - Added `--pre` flag to `pip install` command when installing from TestPyPI

  ## Why This Change?
  By default, `pip install` skips pre-release versions (e.g., `v0.0.1.dev3`) unless explicitly told to include them. Without the `--pre` flag,
   the workflow validation step would fail to find and test development versions published to TestPyPI, defeating the purpose of the
  validation workflow.
