### PR TITLE
Allow manual triggering of PyPI workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -12,11 +12,12 @@ jobs:
   publish-to-pypi:
     name: Publish to PyPI
     # Only run if:
-    # 1. Previous workflow succeeded
-    # 2. Triggered by a version tag
+    # 1. Manual trigger (workflow_dispatch), OR
+    # 2. Automatic trigger: previous workflow succeeded AND triggered by version tag
     if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'v')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -28,7 +29,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          # For workflow_run: use the branch from the triggering workflow
+          # For workflow_dispatch: use the current branch
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.workflow_run.head_branch }}
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Enables manual runs of the PyPI deployment workflow via workflow_dispatch.

## Changes

- Add support for manual workflow triggers via GitHub Actions UI
- Update `if` condition to handle both automatic and manual triggers
- Fix checkout ref to use correct branch for each trigger type

## How to Use

### Automatic (Default)
- Push a version tag (e.g., `v0.1.0`)
- TestPyPI workflow runs → validates → automatically triggers PyPI workflow

### Manual (New)
- Go to Actions tab → "Publish to PyPI" workflow
- Click "Run workflow" → Select branch → Run
- Useful for re-publishing after TestPyPI validation without re-tagging

## Technical Details

**Before** (automatic only):
```yaml
if: |
  github.event.workflow_run.conclusion == 'success' &&
  startsWith(github.event.workflow_run.head_branch, 'v')
```

**After** (automatic + manual):
```yaml
if: |
  github.event_name == 'workflow_dispatch' ||
  (github.event.workflow_run.conclusion == 'success' &&
   startsWith(github.event.workflow_run.head_branch, 'v'))
```

The checkout ref also adapts based on trigger type to use the correct branch.